### PR TITLE
Module customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This consists of using CloudFront/S3 with a Custom Domain to host the MTA-STS po
 
 This module assumes AWS Account with access to Route53, CloudFront, S3, and ACM, which also hosts the DNS (in Route53) for the domain you wish to deploy MTA-STS/TLS-RPT.
 The providers are defined here to allow resources to be provisioned in both `us-east-1` and a local region (`eu-west-2` in this example). This method also allows additional providers to be defined for additional AWS accounts / profiles, if required.
+Note some variables (such as `cf_waf_web_acl`, `cf_price_class`, `mode`, `tags`, etc.) are optional. `See variables.tf` for defaults.
 
 ```terraform
 provider "aws" {
@@ -32,7 +33,9 @@ module "mtastspolicy_examplecom" {
   mx              = ["mail.example.com"]
   mode            = "testing"
   reporting_email = "tlsreporting@example.com"
-  
+  cf_price_class  = "PriceClass_200"
+  cf_waf_web_acl  = "arn:aws:waf___"
+  tags            = { "Terraform_source_repo" = "my-terraform-mta-sts-repo" }
   providers = {
     aws.useast1 = aws.useast1
     aws.account = aws.myregion

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This module assumes AWS Account with access to Route53, CloudFront, S3, and ACM,
 ```terraform
 module "mtastspolicy_examplecom" {
   source          = "github.com/ukncsc/terraform-aws-mtasts"
-  zone_id         = "Z00AAAAAAA0A0A"
   domain          = "example.com"
   mx              = ["mail.example.com"]
   mode            = "testing"

--- a/README.md
+++ b/README.md
@@ -7,13 +7,36 @@ This consists of using CloudFront/S3 with a Custom Domain to host the MTA-STS po
 ## How to use this Module
 
 This module assumes AWS Account with access to Route53, CloudFront, S3, and ACM, which also hosts the DNS (in Route53) for the domain you wish to deploy MTA-STS/TLS-RPT.
+The providers are defined here to allow resources to be provisioned in both `us-east-1` and a local region (`eu-west-2` in this example). This method also allows additional providers to be defined for additional AWS accounts / profiles, if required.
 
 ```terraform
+provider "aws" {
+  alias                    = "useast1"
+  region                   = "us-east-1"
+  shared_config_files      = ["___/.aws/conf"]
+  shared_credentials_files = ["___/.aws/creds"]
+  profile                  = "myprofile"
+}
+
+provider "aws" {
+  alias                    = "myregion"
+  region                   = "eu-west-2"
+  shared_config_files      = ["___/.aws/conf"]
+  shared_credentials_files = ["___/.aws/creds"]
+  profile                  = "myprofile"
+}
+
 module "mtastspolicy_examplecom" {
   source          = "github.com/ukncsc/terraform-aws-mtasts"
   domain          = "example.com"
   mx              = ["mail.example.com"]
   mode            = "testing"
   reporting_email = "tlsreporting@example.com"
+  
+  providers = {
+    aws.useast1 = aws.useast1
+    aws.account = aws.myregion
+  }
+
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -69,10 +69,11 @@ EOF
 }
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
-  aliases  = [local.policydomain]
-  enabled  = true
-  tags     = local.tags
-  provider = aws.account
+  aliases     = [local.policydomain]
+  enabled     = true
+  price_class = var.cf_price_class
+  tags        = local.tags
+  provider    = aws.account
 
   origin {
     domain_name = aws_s3_bucket.policybucket.bucket_regional_domain_name

--- a/main.tf
+++ b/main.tf
@@ -7,12 +7,19 @@ locals {
   policydomain = "mta-sts.${var.domain}"
   policyhash   = md5(format("%s%s%s", join("", var.mx), var.mode, var.max_age))
   s3_origin_id = "myS3Origin"
+  tags         = merge(
+    {
+      "Service" = "MTA-STS"
+      "Domain"  = var.domain
+    },
+    var.tags
+  )
 }
 
 resource "aws_acm_certificate" "cert" {
   domain_name       = local.policydomain
   validation_method = "DNS"
-  tags              = var.tags
+  tags              = local.tags
   provider          = aws.useast1
 }
 

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,11 @@ resource "aws_acm_certificate_validation" "cert" {
 
 resource "aws_s3_bucket" "policybucket" {
   bucket   = local.bucketname
+  provider = aws.account
+}
+
+resource "aws_s3_bucket_acl" "policybucket_acl" {
+  bucket   = aws_s3_bucket.policybucket.id
   acl      = "private"
   provider = aws.account
 }

--- a/main.tf
+++ b/main.tf
@@ -58,11 +58,13 @@ resource "aws_s3_bucket_acl" "policybucket_acl" {
 resource "aws_s3_object" "mtastspolicyfile" {
   key          = ".well-known/mta-sts.txt"
   bucket       = aws_s3_bucket.policybucket.id
-  content      = <<EOF
-version: STSv1
-mode: ${var.mode}
-${join("", formatlist("mx: %s\n", var.mx))}max_age: ${var.max_age}
-EOF
+  content      = templatefile("${path.module}/mta-sts.templatefile",
+    {
+      max_age  = var.max_age
+      mode     = var.mode
+      mx_lines = join("\n", formatlist("mx: %s", var.mx))
+    }
+  )
   content_type = "text/plain"
   tags         = local.tags
   provider     = aws.account

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+  provider = aws.account
+}
 
 locals {
   policydomain = "mta-sts.${var.domain}"

--- a/main.tf
+++ b/main.tf
@@ -6,11 +6,6 @@ locals {
   bucketname   = "mta-sts.${data.aws_caller_identity.current.account_id}.${var.domain}"
 }
 
-provider "aws" {
-  alias  = "useast1"
-  region = "us-east-1"
-}
-
 resource "aws_acm_certificate" "cert" {
   domain_name       = local.policydomain
   validation_method = "DNS"

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   aliases     = [local.policydomain]
   enabled     = true
   price_class = var.cf_price_class
+  web_acl_id  = var.cf_waf_web_acl
   tags        = local.tags
   provider    = aws.account
 

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_acm_certificate" "cert" {
 }
 
 data "aws_route53_zone" "zone" {
-  zone_id  = var.zone_id
+  name     = var.domain
   provider = aws.useast1
 }
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ data "aws_caller_identity" "current" {}
 locals {
   policydomain = "mta-sts.${var.domain}"
   policyhash   = md5(format("%s%s%s", join("", var.mx), var.mode, var.max_age))
-  bucketname   = "${data.aws_caller_identity.current.account_id}.${var.domain}"
+  bucketname   = "mta-sts.${data.aws_caller_identity.current.account_id}.${var.domain}"
 }
 
 provider "aws" {

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_s3_bucket_acl" "policybucket_acl" {
   provider = aws.account
 }
 
-resource "aws_s3_bucket_object" "mtastspolicyfile" {
+resource "aws_s3_object" "mtastspolicyfile" {
   key          = ".well-known/mta-sts.txt"
   bucket       = aws_s3_bucket.policybucket.id
   content      = <<EOF

--- a/main.tf
+++ b/main.tf
@@ -3,9 +3,10 @@ data "aws_caller_identity" "current" {
 }
 
 locals {
+  bucketname   = "mta-sts.${data.aws_caller_identity.current.account_id}.${var.domain}"
   policydomain = "mta-sts.${var.domain}"
   policyhash   = md5(format("%s%s%s", join("", var.mx), var.mode, var.max_age))
-  bucketname   = "mta-sts.${data.aws_caller_identity.current.account_id}.${var.domain}"
+  s3_origin_id = "myS3Origin"
 }
 
 resource "aws_acm_certificate" "cert" {
@@ -56,10 +57,6 @@ ${join("", formatlist("mx: %s\n", var.mx))}max_age: ${var.max_age}
 EOF
   content_type = "text/plain"
   provider     = aws.account
-}
-
-locals {
-  s3_origin_id = "myS3Origin"
 }
 
 resource "aws_cloudfront_distribution" "s3_distribution" {

--- a/mta-sts.templatefile
+++ b/mta-sts.templatefile
@@ -1,0 +1,4 @@
+version: STSv1
+mode: ${mode}
+${mx_lines}
+max_age: ${max_age}

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "zone_id" {
-  type        = string
-  description = "Route53 zone hosting the domain MTA-STS/TLS-RPT is being deployed for."
-}
-
 variable "domain" {
   type        = string
   description = "The domain MTA-STS/TLS-RPT is being deployed for."

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "cf_price_class" {
+  type        = string
+  default     = "PriceClass_100"
+  description = "The price class for the MTA STS CloudFront distribution. Options: PriceClass_100 (North America and Europe), PriceClass_200 (North America, Europe, Asia, Middle East, and Africa) or PriceClass_All (all edge locations)."
+}
+
 variable "domain" {
   type        = string
   description = "The domain MTA-STS/TLS-RPT is being deployed for."

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "cf_price_class" {
   description = "The price class for the MTA STS CloudFront distribution. Options: PriceClass_100 (North America and Europe), PriceClass_200 (North America, Europe, Asia, Middle East, and Africa) or PriceClass_All (all edge locations)."
 }
 
+variable "cf_waf_web_acl" {
+  type        = string
+  default     = null
+  description = "AWS WAF web ACL to associate with the CloudFront distribution."
+}
+
 variable "domain" {
   type        = string
   description = "The domain MTA-STS/TLS-RPT is being deployed for."

--- a/versions.tf
+++ b/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      configuration_aliases = [ aws.account, aws.useast1 ]
     }
   }
 }


### PR DESCRIPTION
Applies the following changes:
- Updates some functions and resources to remove Terraform deprecation warnings.
- Removes the need to provide the Zone Name and ID (since a data source lookup is used anyway).
- Adds a secondary provider to resources can be deployed to local regions.
- Adds a default tag, and adds tagging to all taggable resources.
- Add variables for CloudFront price class and WAF configuration.
- Reconfigures the policy file resource to use a template file. Adds the template file to this repo.
- Updates to readme to include these changes.